### PR TITLE
Updated documentation on installing hubspot

### DIFF
--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/docs/getting-started.md
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/docs/getting-started.md
@@ -11,7 +11,7 @@ Choose the directory in your project where you want to install the connector.
 ### 2. Run the installer
 
 ```bash
-bash -i <(curl https://connectors.514.ai/install.sh) hubspot v3 514-labs typescript
+bash -i <(curl https://connectors.514.ai/install.sh) hubspot v3 514-labs typescript data-api
 ```
 
 ### 3. Build the connector

--- a/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/app/hubspot/docs/getting-started.md
+++ b/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/app/hubspot/docs/getting-started.md
@@ -5,7 +5,7 @@ This package provides a HubSpot CRM v3 connector. It exposes a simple lifecycle 
 ## Install
 
 - Navigate to your project, specifically where you want to install the connector
-- Run `bash -i <(curl https://connectors.514.ai/install.sh) hubspot v3 514-labs typescript`
+- Run `bash -i <(curl https://connectors.514.ai/install.sh) hubspot v3 514-labs typescript data-api`
 - In the hubspot directory, run `npm install && npm run build`
 - Update your project's `package.json` to understand the new connector folder. LLM is great for this!
 - Run `npm install` from your project root to update your `node_modules` with the new connector

--- a/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/docs/configuration.md
+++ b/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/docs/configuration.md
@@ -7,7 +7,7 @@
 ## Connector (v3)
 Install with:
 ```bash
-bash -i <(curl https://connectors.514.ai/install.sh) hubspot v3 514-labs typescript
+bash -i <(curl https://connectors.514.ai/install.sh) hubspot v3 514-labs typescript data-api
 ```
 
 ## Moose runtime


### PR DESCRIPTION
This pull request updates the installation instructions for the HubSpot v3 connector across multiple documentation files to include the `data-api` argument. This ensures users install the correct variant of the connector.

**Documentation updates:**

* Updated the installation command in `connector-registry/hubspot/v3/514-labs/typescript/data-api/docs/getting-started.md` to include the `data-api` argument.
* Updated the installation command in `pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/app/hubspot/docs/getting-started.md` to include the `data-api` argument.
* Updated the installation command in `pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/docs/configuration.md` to include the `data-api` argument.