### PR TITLE
Add post-install instructions (Closes PM-419)

### DIFF
--- a/connector-registry/_scaffold/python.json
+++ b/connector-registry/_scaffold/python.json
@@ -98,6 +98,11 @@
                         },
                         {
                           "type": "file",
+                          "name": "install.config.toml",
+                          "template": "language = \"python\"\ndescription = \"Python connector for {connector}\"\npost_install_print = \"\"\"\n🚀 Next steps to get your {connector} connector running:\n\n📂 Go to your connector directory:\n    $ cd {destination_dir}\n\n🐍 Create virtual environment (recommended):\n    $ python3 -m venv .venv\n    $ source .venv/bin/activate\n\n📦 Install dependencies:\n    $ pip install -e .\n\n🧪 Run tests:\n    $ python -m pytest\n\n📖 Next, check out the documentation:\n    • Review docs/getting-started.md for configuration details\n    • See examples/ for usage examples\n    • Update src/{connector}/connector.py with your API implementation\n\n🔗 Integration options:\n    • Add to your project: from {packageName} import {connector|title}Connector\n    • Use with pipelines: Configure as a source in your pipeline setup\n    • Standalone usage: Check examples/basic_usage.py\n\"\"\"\n"
+                        },
+                        {
+                          "type": "file",
                           "name": "pyproject.toml",
                           "template": "[project]\nname = \"{packageName}\"\nversion = \"0.1.0\"\nreadme = \"README.md\"\nrequires-python = \">=3.10\"\nlicense = {text = \"MIT\"}\nauthors = [ { name = \"{author}\" } ]\ndependencies = [ ]\n\n[tool.ruff]\nline-length = 100\n\n[build-system]\nrequires = [\"setuptools>=68\",\"wheel\"]\nbuild-backend = \"setuptools.build_meta\"\n"
                         },

--- a/connector-registry/_scaffold/typescript.json
+++ b/connector-registry/_scaffold/typescript.json
@@ -98,6 +98,11 @@
                         },
                         {
                           "type": "file",
+                          "name": "install.config.toml",
+                          "template": "language = \"typescript\"\ndescription = \"TypeScript connector for {connector}\"\npost_install_print = \"\"\"\n🚀 Next steps to get your {connector} connector running:\n\n📂 Go to your connector directory:\n    $ cd {destination_dir}\n\n📦 Install dependencies:\n    $ npm install\n\n🔧 Build the connector:\n    $ npm run build\n\n🧪 Run tests:\n    $ npm test\n\n📖 Next, check out the documentation:\n    • Review docs/getting-started.md for configuration details\n    • See examples/ for usage examples\n    • Update src/connector.ts with your API implementation\n\n🔗 Integration options:\n    • Add to your project: import { create{connector|title}Connector } from '{packageName}'\n    • Use with pipelines: Configure as a source in your pipeline setup\n    • Standalone usage: Check examples/basic-usage.ts\n\"\"\"\n"
+                        },
+                        {
+                          "type": "file",
                           "name": "package.json",
                           "template": "{\n  \"name\": \"{packageName}\",\n  \"version\": \"0.1.0\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"main\": \"dist/index.js\",\n  \"types\": \"dist/index.d.ts\",\n  \"scripts\": {\n    \"build\": \"tsup src/index.ts --dts --format esm,cjs\",\n    \"test\": \"vitest run\"\n  },\n  \"engines\": {\"node\": \">=20\"},\n  \"dependencies\": {},\n  \"devDependencies\": {\n    \"tsup\": \"^8.0.0\",\n    \"typescript\": \"^5.4.0\",\n    \"vitest\": \"^1.6.0\"\n  }\n}\n"
                         },

--- a/connector-registry/hubspot/v3/514-labs/typescript/data-api/install.config.toml
+++ b/connector-registry/hubspot/v3/514-labs/typescript/data-api/install.config.toml
@@ -1,0 +1,13 @@
+language = "typescript"
+description = "TypeScript connector for HubSpot CRM API (v3)"
+post_install_print = """
+🚀 Next steps for your HubSpot connector:
+
+📂 Go to your connector directory:
+    $ cd {destination_dir}
+
+📖 Read the documentation:
+    • Check out README.md for overview and setup
+    • Review docs/getting-started.md for detailed instructions
+    • See examples/basic-usage.ts for implementation examples
+"""

--- a/pipeline-registry/_scaffold/python.json
+++ b/pipeline-registry/_scaffold/python.json
@@ -125,6 +125,11 @@
                         },
                         {
                           "type": "file",
+                          "name": "install.config.toml",
+                          "template": "language = \"python\"\ndescription = \"Python pipeline for {pipeline}\"\npost_install_print = \"\"\"\n🚀 Next steps to get your {pipeline} pipeline running:\n\n📂 Go to your pipeline directory:\n    $ cd {destination_dir}\n\n🐍 Create virtual environment (recommended):\n    $ python3 -m venv .venv\n    $ source .venv/bin/activate\n\n📦 Install dependencies:\n    $ pip install -e .\n\n🧪 Run tests:\n    $ python -m pytest\n\n🗄️ Configure your pipeline:\n    • Update app/config.py with your source connector details\n    • Configure your destination in the pipeline metadata\n    • Set up any required authentication credentials\n\n🔗 Pipeline integration:\n    • Use with Moose: Place in your Moose project's pipelines directory\n    • Standalone: Run with your preferred orchestration tool\n    • Check examples/basic_usage.py for implementation patterns\n\n📖 Documentation:\n    • Review docs/getting-started.md for setup instructions\n    • See docs/configuration.md for detailed config options\n    • Check docs/outputs.md for data schema information\n\"\"\"\n"
+                        },
+                        {
+                          "type": "file",
                           "name": "pyproject.toml",
                           "template": "[project]\nname = \"{packageName}\"\nversion = \"0.1.0\"\nreadme = \"README.md\"\nrequires-python = \">=3.10\"\nlicense = {text = \"MIT\"}\nauthors = [ { name = \"{author}\" } ]\ndependencies = [ ]\n\n[tool.ruff]\nline-length = 100\n\n[build-system]\nrequires = [\"setuptools>=68\",\"wheel\"]\nbuild-backend = \"setuptools.build_meta\"\n"
                         },

--- a/pipeline-registry/_scaffold/typescript.json
+++ b/pipeline-registry/_scaffold/typescript.json
@@ -125,6 +125,11 @@
                         },
                         {
                           "type": "file",
+                          "name": "install.config.toml",
+                          "template": "language = \"typescript\"\ndescription = \"TypeScript pipeline for {pipeline}\"\npost_install_print = \"\"\"\n🚀 Next steps to get your {pipeline} pipeline running:\n\n📂 Go to your pipeline directory:\n    $ cd {destination_dir}\n\n📦 Install dependencies:\n    $ npm install\n\n🔧 Build the pipeline:\n    $ npm run build\n\n🧪 Run tests:\n    $ npm test\n\n🗄️ Configure your pipeline:\n    • Update app/config.ts with your source connector details\n    • Configure your destination in the pipeline metadata\n    • Set up any required authentication credentials\n\n🔗 Pipeline integration:\n    • Use with Moose: Place in your Moose project's pipelines directory\n    • Standalone: Run with your preferred orchestration tool\n    • Check examples/basic-usage.ts for implementation patterns\n\n📖 Documentation:\n    • Review docs/getting-started.md for setup instructions\n    • See docs/configuration.md for detailed config options\n    • Check docs/outputs.md for data schema information\n\"\"\"\n"
+                        },
+                        {
+                          "type": "file",
                           "name": "package.json",
                           "template": "{\n  \"name\": \"{packageName}\",\n  \"version\": \"0.1.0\",\n  \"private\": true,\n  \"type\": \"module\",\n  \"main\": \"dist/index.js\",\n  \"types\": \"dist/index.d.ts\",\n  \"scripts\": {\n    \"build\": \"tsup src/index.ts --dts --format esm,cjs\",\n    \"test\": \"vitest run\"\n  },\n  \"engines\": {\"node\": \">=20\"},\n  \"dependencies\": {},\n  \"devDependencies\": {\n    \"tsup\": \"^8.0.0\",\n    \"typescript\": \"^5.4.0\",\n    \"vitest\": \"^1.6.0\"\n  }\n}\n"
                         },

--- a/pipeline-registry/google-analytics-to-clickhouse/v1/514-labs/typescript/default/install.config.toml
+++ b/pipeline-registry/google-analytics-to-clickhouse/v1/514-labs/typescript/default/install.config.toml
@@ -1,0 +1,24 @@
+language = "typescript"
+description = "TypeScript pipeline for Google Analytics to ClickHouse"
+post_install_print = """
+🚀 Next steps for your Google Analytics to ClickHouse pipeline:
+
+📂 Go to your pipeline directory:
+    $ cd {destination_dir}
+
+🔑 Set environment variables:
+    $ export GA_PROPERTY_ID=your_property_id_here
+    $ export CLICKHOUSE_URL=your_clickhouse_url
+    $ export CLICKHOUSE_DATABASE=your_database
+
+📦 Install dependencies:
+    $ npm install
+
+🚀 Start development:
+    $ npm run dev
+
+📖 Next steps:
+    • Review docs/getting-started.md for configuration details
+    • Check docs/configuration.md for environment setup
+    • See examples/basic-usage.ts for usage patterns
+"""

--- a/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/install.config.toml
+++ b/pipeline-registry/hubspot-to-clickhouse/v3/514-labs/typescript/default/install.config.toml
@@ -1,0 +1,17 @@
+language = "typescript"
+description = "TypeScript pipeline for HubSpot to ClickHouse"
+post_install_print = """
+🚀 Next steps for your HubSpot to ClickHouse pipeline:
+
+📂 Go to your pipeline directory:
+    $ cd {destination_dir}
+
+🔑 Set environment variables:
+    $ export HUBSPOT_ACCESS_TOKEN=your_token_here
+
+📦 Install dependencies:
+    $ npm install
+
+🚀 Start development:
+    $ npm run dev
+"""


### PR DESCRIPTION
# improve user onboarding

This feature provides clear, context-specific next steps after installing connectors/pipelines, solving the issue where users were left without guidance after installation.

## Developer Experience
- Add install.config.toml files with post_install_print sections
- Use placeholders like {destination_dir}, {connector}, {pipeline} for dynamic content
- Different templates: connectors focus on docs, pipelines show full setup workflow
- Added to scaffolds so new resources automatically include post-install guidance

## User Experience
- Install script displays formatted instructions after successful installation
- Clear visual separation with ================================================== borders
- Context-aware: pipelines show 'cd → set env → npm install → npm run dev'
- Connectors show 'cd → read README/docs/examples'
- Fallback to generic guidance when no custom config exists

## Implementation
- Enhanced install.sh with parse_toml_value() using awk for multi-line strings
- Added install.config.toml to all scaffolds (TypeScript/Python, connector/pipeline)
- Created configs for existing resources (HubSpot connector, GA→ClickHouse pipeline)
- Placeholder replacement system for personalized instructions