### PR TITLE
Card UI Fixes

### DIFF
--- a/apps/registry-docs/app/discover/pipeline/pipeline-discover-grid.tsx
+++ b/apps/registry-docs/app/discover/pipeline/pipeline-discover-grid.tsx
@@ -40,7 +40,7 @@ export default function PipelineDiscoverGrid({
   return (
     <div
       className={cn(
-        "grid grid-cols-3 gap-4 @xl/main:grid-cols-2 @5xl/main:grid-cols-3",
+        "grid grid-cols-2 gap-4 @xl/main:grid-cols-2 @5xl/main:grid-cols-3",
         className
       )}
     >

--- a/apps/registry-docs/components/connector-card.tsx
+++ b/apps/registry-docs/components/connector-card.tsx
@@ -87,16 +87,16 @@ function ConnectorCard({
       <Card className="h-full group cursor-pointer transition-colors hover:bg-muted/40">
         <CardHeader className="flex flex-row items-start justify-between">
           {imageError ? (
-            <div className="h-12 w-12 rounded-sm bg-muted text-muted-foreground ring-1 ring-border flex items-center justify-center">
+            <div className="h-10 w-10 rounded-sm bg-muted text-muted-foreground ring-1 ring-border flex items-center justify-center">
               <DefaultIcon size={24} />
             </div>
           ) : (
             <Image
               src={imageSrc}
               alt={`${name} logo`}
-              width={48}
-              height={48}
-              className="h-12 w-12 rounded-sm object-contain 0"
+              width={40}
+              height={40}
+              className="h-10 w-10 rounded-sm object-contain 0"
               onError={() => setImageError(true)}
             />
           )}
@@ -137,9 +137,9 @@ function ConnectorCard({
                   key={`${url}-${idx}`}
                   src={url}
                   alt="Creator avatar"
-                  width={24}
-                  height={24}
-                  className="h-6 w-6 rounded-full ring-1 ring-background"
+                  width={32}
+                  height={32}
+                  className="h-8 w-8 rounded-full mt-2"
                   unoptimized
                 />
               ))}
@@ -153,41 +153,49 @@ function ConnectorCard({
             <Image
               src={creatorAvatarUrl}
               alt="Creator avatar"
-              width={24}
-              height={24}
-              className="h-6 w-6 rounded-full mt-2"
+              width={32}
+              height={32}
+              className="h-8 w-8 rounded-full mt-2"
               unoptimized
             />
           ) : null}
         </CardContent>
         <CardFooter className="flex flex-col gap-4 items-start">
-          <p className="text-sm text-muted-foreground">{description}</p>
+          <p className="text-sm text-muted-foreground line-clamp-2">{description}</p>
           <div className="flex flex-wrap gap-2">
-            {(languages && languages.length > 0
-              ? languages
-              : language
-                ? [language]
-                : []
-            ).map((lang) => (
-              <Badge key={`lang-${lang}`} variant="secondary">
-                {lang}
-              </Badge>
-            ))}
-            {sourceType ? (
-              <Badge key={`type-${sourceType}`} variant="secondary">
-                {sourceType}
-              </Badge>
-            ) : null}
-            {(domains ?? []).map((d) => (
-              <Badge key={`domain-${d}`} variant="secondary">
-                {d}
-              </Badge>
-            ))}
-            {tags.map((tag) => (
-              <Badge key={tag} variant="secondary">
-                {tag}
-              </Badge>
-            ))}
+            {(() => {
+              // Collect all badges into a single array
+              const allBadges = [
+                ...(languages && languages.length > 0
+                  ? languages.map((lang) => ({ key: `lang-${lang}`, label: lang }))
+                  : language
+                    ? [{ key: `lang-${language}`, label: language }]
+                    : []
+                ),
+                ...(sourceType ? [{ key: `type-${sourceType}`, label: sourceType }] : []),
+                ...(domains ?? []).map((d) => ({ key: `domain-${d}`, label: d })),
+                ...tags.map((tag) => ({ key: tag, label: tag })),
+              ];
+
+              const maxVisible = 2;
+              const visibleBadges = allBadges.slice(0, maxVisible);
+              const remainingCount = allBadges.length - maxVisible;
+
+              return (
+                <>
+                  {visibleBadges.map((badge) => (
+                    <Badge key={badge.key} variant="secondary">
+                      {badge.label}
+                    </Badge>
+                  ))}
+                  {remainingCount > 0 && (
+                    <Badge variant="secondary" className="text-muted-foreground">
+                      +{remainingCount}
+                    </Badge>
+                  )}
+                </>
+              );
+            })()}
           </div>
         </CardFooter>
       </Card>

--- a/apps/registry-docs/components/pipeline-card.tsx
+++ b/apps/registry-docs/components/pipeline-card.tsx
@@ -100,9 +100,9 @@ export default function PipelineCard({
                 <Image
                   src={sourceLogo}
                   alt={`${sourceSystem} logo`}
-                  width={32}
-                  height={32}
-                  className="h-8 w-8 rounded-sm object-contain"
+                  width={40}
+                  height={40}
+                  className="h-10 w-10 rounded-sm object-contain"
                 />
               ) : null}
               <span className="text-muted-foreground">→</span>
@@ -110,9 +110,9 @@ export default function PipelineCard({
                 <Image
                   src={destinationLogo}
                   alt={`${destinationSystem} logo`}
-                  width={32}
-                  height={32}
-                  className="h-8 w-8 rounded-sm object-contain"
+                  width={40}
+                  height={40}
+                  className="h-10 w-10 rounded-sm object-contain 0"
                 />
               ) : null}
             </div>
@@ -120,9 +120,9 @@ export default function PipelineCard({
             <Image
               src={imageSrc}
               alt={`${name} logo`}
-              width={48}
-              height={48}
-              className="h-12 w-12 rounded-sm object-contain 0"
+              width={40}
+              height={40}
+              className="h-10 w-10 rounded-sm object-contain 0"
             />
           )}
           <div className="flex items-center gap-2">
@@ -162,14 +162,14 @@ export default function PipelineCard({
                   key={`${url}-${idx}`}
                   src={url}
                   alt="Creator avatar"
-                  width={24}
-                  height={24}
-                  className="h-6 w-6 rounded-full ring-1 ring-background"
+                  width={32}
+                  height={32}
+                  className="h-8 w-8 rounded-full ring-1 ring-background"
                   unoptimized
                 />
               ))}
               {creatorAvatarUrls.length > 5 ? (
-                <div className="h-6 w-6 rounded-full bg-muted text-xs flex items-center justify-center ring-1 ring-background">
+                <div className="h-8 w-8 rounded-full bg-muted text-xs flex items-center justify-center ring-1 ring-background">
                   +{creatorAvatarUrls.length - 5}
                 </div>
               ) : null}
@@ -178,9 +178,9 @@ export default function PipelineCard({
             <Image
               src={creatorAvatarUrl}
               alt="Creator avatar"
-              width={24}
-              height={24}
-              className="h-6 w-6 rounded-full mt-2"
+              width={32}
+              height={32}
+              className="h-8 w-8 rounded-full mt-2"
               unoptimized
             />
           ) : null}
@@ -200,18 +200,34 @@ export default function PipelineCard({
           ) : null}
         </CardContent>
         <CardFooter className="flex flex-col gap-3 items-start">
-          <p className="text-sm text-muted-foreground">{description}</p>
-          <div className="flex flex-wrap gap-2">
-            {(languages ?? []).map((lang) => (
-              <Badge key={`lang-${lang}`} variant="secondary">
-                {lang}
-              </Badge>
-            ))}
-            {tags.map((tag) => (
-              <Badge key={tag} variant="secondary">
-                {tag}
-              </Badge>
-            ))}
+        <p className="text-sm text-muted-foreground line-clamp-2">{description}</p>
+        <div className="flex flex-wrap gap-2">
+            {(() => {
+              // Collect all badges into a single array
+              const allBadges = [
+                ...(languages ?? []).map((lang) => ({ key: `lang-${lang}`, label: lang })),
+                ...tags.map((tag) => ({ key: tag, label: tag })),
+              ];
+
+              const maxVisible = 3;
+              const visibleBadges = allBadges.slice(0, maxVisible);
+              const remainingCount = allBadges.length - maxVisible;
+
+              return (
+                <>
+                  {visibleBadges.map((badge) => (
+                    <Badge key={badge.key} variant="secondary">
+                      {badge.label}
+                    </Badge>
+                  ))}
+                  {remainingCount > 0 && (
+                    <Badge variant="secondary" className="text-muted-foreground">
+                      +{remainingCount}
+                    </Badge>
+                  )}
+                </>
+              );
+            })()}
           </div>
         </CardFooter>
       </Card>


### PR DESCRIPTION
Card styling fixes to help with overflow issues:

• Reduced badge wrapping to max # badges with +count indicator for overflow 
• Max 2 lines for card descriptions with truncation to avoid inconsistent scan lines
• Standardized card icon sizes to 40x40px
• Increased creator avatar sizes to 32x32px
• 2-column grid layout for pipeline discovery to avoid impl. collision

