### PR TITLE
Fix SAP HANA CDC connector documentation

### DIFF
--- a/connector-registry/sap_hana_cdc/v1/514-labs/python/default/docs/getting-started.md
+++ b/connector-registry/sap_hana_cdc/v1/514-labs/python/default/docs/getting-started.md
@@ -12,7 +12,7 @@ This guide will help you set up and start using the SAP HANA CDC connector.
 
 1. Install the connector:
    ```bash
-   bash -i <(curl https://registry.514.ai/install.sh) --dest app/sap-hana-cdc sap-hana-cdc v1 514-labs python default
+   bash -i <(curl https://registry.514.ai/install.sh) --dest app/sap_hana_cdc sap_hana_cdc v1 514-labs python default
    ```
 
 ## Basic Configuration
@@ -76,9 +76,3 @@ for change in changes.changes:
     if change.old_values:
         print(f"Old values: {change.old_values}")
 ```
-
-## Next Steps
-
-- Review the [Configuration](configuration.md) guide for advanced options
-- Check the [Schema Reference](schema.md) for data structure details
-- See [Limits and Considerations](limits.md) for important constraints


### PR DESCRIPTION
## Summary
- Fixed installation command to use correct connector name (`sap_hana_cdc` instead of `sap-hana-cdc`)
- Removed broken Next Steps section that had non-functional documentation links

## Test plan
- [ ] Verify installation command uses correct connector name with underscores
- [ ] Confirm Next Steps section is removed from getting-started guide
- [ ] Check that documentation renders correctly on registry website

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (install snippet and link removal) with no runtime or API impact.
> 
> **Overview**
> Fixes the `getting-started.md` install command to use the correct connector/package name (`sap_hana_cdc`) and destination path (underscores instead of hyphens).
> 
> Removes the “Next Steps” section that referenced non-functional documentation links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d07d0ad8b8d459e8b21540f2513bb89ecb5ff529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->